### PR TITLE
Exclude all-numeric hostnames from passing validation per RFC 3696

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function isValidHostname(value, opts) {
   }
 
   if (value.endsWith('.')) {
-    value = value.slice(0, value.length-1)
+    value = value.slice(0, value.length - 1)
   }
 
   if (value.length > 253) {
@@ -17,7 +17,7 @@ module.exports = function isValidHostname(value, opts) {
 
   const labels = value.split('.')
 
-  const isValid = labels.every(function(label) {
+  const isInitiallyValid = labels.every(function (label) {
     const validLabelChars = /^([a-zA-Z0-9-]+)$/g
 
     const validLabel = (
@@ -30,5 +30,12 @@ module.exports = function isValidHostname(value, opts) {
     return validLabel
   })
 
-  return isValid
+  // check to ensure all-numeric values don't pass validation
+  // only values with more than one numeric label may have the invalid all-numeric case
+  let isAllNumeric = false
+  if (labels.length > 1) {
+    isAllNumeric = labels.every((label) => label.match(/^[0-9]*$/))
+  }
+
+  return isInitiallyValid && !isAllNumeric
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 var test = require('tape')
 var isValidHostname = require('../')
 
-test('is valid hostname', function(t) {
+test('is valid hostname', function (t) {
   t.plan(78)
 
   // tld and subdomains
@@ -64,7 +64,6 @@ test('is valid hostname', function(t) {
 
   // valid labels
   t.equal(isValidHostname('localhost'), true)
-  t.equal(isValidHostname('127.0.0.1'), true)
   t.equal(isValidHostname('example'), true)
   t.equal(isValidHostname('exa-mple'), true)
   t.equal(isValidHostname('3434'), true)
@@ -77,6 +76,7 @@ test('is valid hostname', function(t) {
   t.equal(isValidHostname(`${'a'.repeat(63)}.${'b'.repeat(63)}.${'c'.repeat(63)}.${'c'.repeat(62)}`), false)
 
   // invalid labels
+  t.equal(isValidHostname("127.0.0.1"), false)
   t.equal(isValidHostname('example..comw'), false)
   t.equal(isValidHostname('a'.repeat(64)), false)
   t.equal(isValidHostname('-exa-mple'), false)
@@ -95,7 +95,7 @@ test('is valid hostname', function(t) {
   // invalid types
   t.equal(isValidHostname(3434), false)
   t.equal(isValidHostname({}), false)
-  t.equal(isValidHostname(function(){}), false)
+  t.equal(isValidHostname(function () { }), false)
 
   // invalid values
   t.equal(isValidHostname('foo.example.com*'), false)


### PR DESCRIPTION
I decided to code up the fix to the [issue](https://github.com/miguelmota/is-valid-hostname/issues/1) I'd reported. 😄 